### PR TITLE
configure goreleaser for sha512 checksum algorithm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,8 @@ builds:
 checksum:
   # You can change the name of the checksums file.
   # Default is `{{ .ProjectName }}_{{ .Version }}_checksums.txt`.
-  name_template: "{{ .ProjectName }}_{{ .Version }}_sha256-checksums.txt"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_sha512-checksums.txt"
+  algorithm: sha512
 
 archive:
   format: tar.gz


### PR DESCRIPTION
This change modifies the configuration of goreleaser to generate checksums using the sha512 algorithm, as this is most expedient for use with Sensu Go and/or Bonsai.