### PR TITLE
Add Sensu event to OpsGenie note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Added the Sensu event json dump to the OpsGenie `Note` field.
+
 ## [0.0.8] - 2020-01-20
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/main.go
+++ b/main.go
@@ -239,6 +239,10 @@ func run(cmd *cobra.Command, args []string) error {
 
 // createIncident func create an alert in OpsGenie
 func createIncident(alertCli *ogcli.OpsGenieAlertV2Client, event *types.Event) error {
+	note, err := getNote(event)
+	if err != nil {
+		return err
+	}
 
 	teams := []alerts.TeamRecipient{
 		&alerts.Team{Name: team},
@@ -252,6 +256,7 @@ func createIncident(alertCli *ogcli.OpsGenieAlertV2Client, event *types.Event) e
 		Entity:      event.Entity.Name,
 		Source:      source,
 		Priority:    eventPriority(event),
+		Note:        note,
 	}
 
 	response, err := alertCli.Create(request)
@@ -322,4 +327,12 @@ func addNote(alertCli *ogcli.OpsGenieAlertV2Client, event *types.Event, alertid 
 	}
 	fmt.Println("RequestID: " + response.RequestID)
 	return nil
+}
+
+func getNote(event *types.Event) (string, error) {
+	eventJSON, err := json.Marshal(event)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Event data update:\n\n%s", eventJSON), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNote(t *testing.T) {
+	event := types.FixtureEvent("foo", "bar")
+	eventJSON, err := json.Marshal(event)
+	assert.NoError(t, err)
+	note, err := getNote(event)
+	assert.NoError(t, err)
+	assert.Contains(t, note, "Event data update:\n\n")
+	assert.Contains(t, note, string(eventJSON))
+}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

Adds the Sensu event json dump to the OpsGenie `Note` field, per parity with the [classic implementation](https://github.com/sensu/sensu-enterprise/blob/67290f241a7ca20079930a9503969ae3b135483f/lib/sensu/enterprise/extensions/handlers/opsgenie.rb#L61-L70).

Closes https://github.com/betorvs/sensu-opsgenie-handler/issues/8